### PR TITLE
Decide room endpoint based on environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,28 +61,15 @@ To run this demo locally:
 
 ### Creating new rooms locally
 
-To create rooms new rooms via the app UI while testing locally, follow these additional steps:
+To create new rooms via the app UI while testing locally, follow these additional steps:
 
 - rename `example.env` to `.env`
 - add your Daily API key (available in the Daily [dashboard](https://dashboard.daily.co/developers)) to `.env`
+- add the value `local` to the `REACT_APP_ROOM_ENDPOINT` variable in `.env`
 
-```
-REACT_APP_DAILY_API_KEY=<-Your Daily API key here->
-```
-
-- In `api.js`, comment out the default request and uncomment the local request.
-
-```javascript
-// api.js
-// make sure this request is uncommented and the one above it is commented out
-const response = await fetch(`https://api.daily.co/v1/rooms/`, {
-  method: 'POST',
-  body: JSON.stringify(options),
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: 'Bearer ' + process.env.REACT_APP_DAILY_API_KEY,
-  },
-});
+```dotenv
+REACT_APP_DAILY_API_KEY=your-daily-api-key
+REACT_APP_ROOM_ENDPOINT=local
 ```
 
 - Restart your server, i.e. re-run `npm start`
@@ -95,6 +82,6 @@ If you want access to the Daily REST API (using the proxy as specified in `netli
 
 [![Deploy with Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daily-demos/custom-video-daily-react-hooks)
 
-Note: You'll need your [Daily API key](https://dashboard.daily.co/developers) handy for this step.
+Note: You'll need your [Daily API key](https://dashboard.daily.co/developers) handy for this step. 
 
 Visit the deployed domain provided by Netlify after completing this step to view the app.

--- a/example.env
+++ b/example.env
@@ -1,1 +1,2 @@
 REACT_APP_DAILY_API_KEY=do-not-share-me-with-anyone-else
+REACT_APP_ROOM_ENDPOINT=local-or-null

--- a/src/App.js
+++ b/src/App.js
@@ -172,8 +172,8 @@ export default function App() {
         <div className="api-error">
           <h1>Error</h1>
           <p>
-            Room could not be created. Please check your local configuration in `api.js`. For more
-            information, check out the{' '}
+            Room could not be created. Check if your `.env` file is set up correctly. For more
+            information, see the{' '}
             <a href="https://github.com/daily-demos/call-object-react-daily-hooks/blob/main/README.md">
               readme
             </a>{' '}

--- a/src/api.js
+++ b/src/api.js
@@ -10,27 +10,27 @@ async function createRoom() {
     },
   };
 
-  /*
-    This endpoint is using the proxy as outlined in netlify.toml.
-    Comment this out if you want to use the local option below.
-  */
-  const response = await fetch(`${window.location.origin}/api/rooms`, {
-    method: 'POST',
-    body: JSON.stringify(options),
-  });
+  const isLocal = process.env.REACT_APP_ROOM_ENDPOINT && process.env.REACT_APP_ROOM_ENDPOINT === 'local';
+  const endpoint = isLocal
+    ? 'https://api.daily.co/v1/rooms/'
+    : `${window.location.origin}/api/rooms`;
 
   /*
-    Uncomment the request below to test the "create room" functionality locally.
-    Don't forget to comment out the request above, too!
+    No need to send the headers with the request when using the proxy option:
+    netlify.toml takes care of that for us.
   */
-  // const response = await fetch(`https://api.daily.co/v1/rooms/`, {
-  //   method: 'POST',
-  //   body: JSON.stringify(options),
-  //   headers: {
-  //     'Content-Type': 'application/json',
-  //     Authorization: `Bearer ${process.env.REACT_APP_DAILY_API_KEY}`,
-  //   },
-  // });
+  const headers = isLocal && {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.REACT_APP_DAILY_API_KEY}`,
+    },
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    body: JSON.stringify(options),
+    ...headers,
+  });
 
   return response.json();
 }


### PR DESCRIPTION
This PR adds an environment variable, `REACT_APP_ROOM_ENDPOINT`. If this variable is set to `local`, the room creation endpoint used will be `https://api.daily.co/v1/rooms/`. This is best for local development. If this variable is not set, or set to anything but `local`, the Netlify proxy option is automatically used.

The upside of this is that anyone checking out the code of this demo won't have to make changes in `api.js` before running the demo locally!