### PR TITLE
Only create audio element for remote participants

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -5,30 +5,34 @@ import Username from '../Username/Username';
 import TileVideo from '../TileVideo/TileVideo';
 
 export default function Tile({ id, isScreenShare, isLocal, isAlone }) {
-  const audioTrack = useMediaTrack(id, isScreenShare ? 'screenAudio' : 'audio');
-  const audioElement = useRef(null);
-
-  useEffect(() => {
-    if (audioTrack?.state === 'playable') {
-      if (audioElement?.current) {
-        (audioElement.current.srcObject =
-          audioTrack && new MediaStream([audioTrack.persistentTrack]));
-      }
-    }
-  }, [audioTrack]);
   let containerCssClasses = isScreenShare ? 'tile-screenshare' : 'tile-video';
-
+  let audioTrack = null;
+  let audioElement = null;
+  
   if (isLocal) {
     containerCssClasses += ' self-view';
     if (isAlone) {
       containerCssClasses += ' alone';
     }
+  } else {
+    // Only create audio track and element if the participant is not local.
+    audioTrack = useMediaTrack(id, isScreenShare ? 'screenAudio' : 'audio');
+    audioElement = useRef(null);
+
+    useEffect(() => {
+      if (audioTrack?.state === 'playable') {
+        if (audioElement?.current) {
+          (audioElement.current.srcObject =
+            audioTrack && new MediaStream([audioTrack.persistentTrack]));
+        }
+      }
+    }, [audioTrack]);
   }
 
   return (
     <div className={containerCssClasses}>
       <TileVideo id={id} isScreenShare={isScreenShare} />
-      {audioTrack && <audio autoPlay playsInline ref={audioElement} />}
+      {!isLocal && audioTrack && <audio autoPlay playsInline ref={audioElement} />}
       <Username id={id} isLocal={isLocal} />
     </div>
   );


### PR DESCRIPTION
The purpose of this PR is to resolve issue #18 

Only create an audio element for remote participants, not local ones.